### PR TITLE
Remove double significance information in last row

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sjtable2df
 Title: Convert 'sjPlot' HTML-Tables to R 'data.frame'
-Version: 0.0.2.9002
+Version: 0.0.2.9003
 Authors@R: 
     person("Lorenz A.", "Kapsner", , "lorenz.kapsner@gmail.com", role = c("cre", "aut", "cph"),
            comment = c(ORCID = "0000-0003-1866-860X"))
@@ -29,6 +29,6 @@ Suggests:
     testthat (>= 3.0.1)
 VignetteBuilder: 
     knitr
-Date/Publication: 2022-09-02 12:24:21 UTC
+Date/Publication: 2022-12-03 07:38:03 UTC
 Encoding: UTF-8
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,6 @@ Suggests:
     testthat (>= 3.0.1)
 VignetteBuilder: 
     knitr
-Date/Publication: 2022-12-03 07:38:03 UTC
+Date/Publication: 2022-12-05 07:52:34 UTC
 Encoding: UTF-8
 RoxygenNote: 7.2.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # sjtable2df NEWS
 
-## Unreleased (2022-09-02)
+## Unreleased (2022-12-02)
 
 #### Refactorings
 
@@ -18,6 +18,10 @@
 
 #### Other changes
 
+-   remove double significance information
+    ([78aaf33](https://github.com/kapsner/sjtable2df/tree/78aaf33817e8dcd8a8b477320b27e35fdf06fd76))
+-   updated news.md
+    ([e5b2ddf](https://github.com/kapsner/sjtable2df/tree/e5b2ddf8ecd7b42511ef3fbf90229a77fafc2ceb))
 -   merged development into main
     ([ce2227a](https://github.com/kapsner/sjtable2df/tree/ce2227a21bd3f3548916c773f775dc5ead776927))
 -   changelog now with autonewsmd
@@ -28,7 +32,7 @@
     ([fc1faf4](https://github.com/kapsner/sjtable2df/tree/fc1faf416482bed9ea39f595eedd894e5dddc0ed))
 
 Full set of changes:
-[`v0.0.2...ce2227a`](https://github.com/kapsner/sjtable2df/compare/v0.0.2...ce2227a)
+[`v0.0.2...78aaf33`](https://github.com/kapsner/sjtable2df/compare/v0.0.2...78aaf33)
 
 ## v0.0.2 (2022-06-20)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,88 +1,150 @@
 # sjtable2df NEWS
 
-## Unreleased (2022-12-02)
+## Unreleased (2022-12-05)
 
 #### Refactorings
 
+-   added checks for replacing values in last row of mtab
+    ([b87ed08](https://github.com/joundso/sjtable2df/tree/b87ed081754363df92e43d34c26590f3fc8e0fb4)) -
+    added checks for replacing values in last row of mtab
+    ([b87ed08](https://github.com/kapsner/sjtable2df/tree/b87ed081754363df92e43d34c26590f3fc8e0fb4))
 -   simplifying utf8 replacements
+    ([2ba438e](https://github.com/joundso/sjtable2df/tree/2ba438e0d5d1b31064d713277f4270f8120e0462)) -
+    simplifying utf8 replacements
     ([2ba438e](https://github.com/kapsner/sjtable2df/tree/2ba438e0d5d1b31064d713277f4270f8120e0462))
 
 #### CI
 
 -   devtools dependencies to tic.r
+    ([9b75143](https://github.com/joundso/sjtable2df/tree/9b75143c747a36bdb2f86c1c6c804319def85b5f)) -
+    devtools dependencies to tic.r
     ([9b75143](https://github.com/kapsner/sjtable2df/tree/9b75143c747a36bdb2f86c1c6c804319def85b5f))
 -   updated lint-stage
+    ([300723b](https://github.com/joundso/sjtable2df/tree/300723b096f51c3bb06940bcc1ab49a2362f5c20)) -
+    updated lint-stage
     ([300723b](https://github.com/kapsner/sjtable2df/tree/300723b096f51c3bb06940bcc1ab49a2362f5c20))
 -   updated gha
+    ([82b3a66](https://github.com/joundso/sjtable2df/tree/82b3a66a857688c4328dcf653b3985248c5888ec)) -
+    updated gha
     ([82b3a66](https://github.com/kapsner/sjtable2df/tree/82b3a66a857688c4328dcf653b3985248c5888ec))
 
 #### Other changes
 
+-   merge main
+    ([42f5f44](https://github.com/joundso/sjtable2df/tree/42f5f44410c3158b9254521d07d3419caaebcfd9)) -
+    merge main
+    ([42f5f44](https://github.com/kapsner/sjtable2df/tree/42f5f44410c3158b9254521d07d3419caaebcfd9))
 -   remove double significance information
+    ([78aaf33](https://github.com/joundso/sjtable2df/tree/78aaf33817e8dcd8a8b477320b27e35fdf06fd76)) -
+    remove double significance information
     ([78aaf33](https://github.com/kapsner/sjtable2df/tree/78aaf33817e8dcd8a8b477320b27e35fdf06fd76))
 -   updated news.md
+    ([e5b2ddf](https://github.com/joundso/sjtable2df/tree/e5b2ddf8ecd7b42511ef3fbf90229a77fafc2ceb)) -
+    updated news.md
     ([e5b2ddf](https://github.com/kapsner/sjtable2df/tree/e5b2ddf8ecd7b42511ef3fbf90229a77fafc2ceb))
 -   merged development into main
+    ([ce2227a](https://github.com/joundso/sjtable2df/tree/ce2227a21bd3f3548916c773f775dc5ead776927)) -
+    merged development into main
     ([ce2227a](https://github.com/kapsner/sjtable2df/tree/ce2227a21bd3f3548916c773f775dc5ead776927))
 -   changelog now with autonewsmd
+    ([d502b46](https://github.com/joundso/sjtable2df/tree/d502b462f36dcb130d660674206037c13dda9574)) -
+    changelog now with autonewsmd
     ([d502b46](https://github.com/kapsner/sjtable2df/tree/d502b462f36dcb130d660674206037c13dda9574))
 -   changelog now with autonewsmd
+    ([5a32908](https://github.com/joundso/sjtable2df/tree/5a3290865b1a9f189ebe81f83d4d7a132ac2a617)) -
+    changelog now with autonewsmd
     ([5a32908](https://github.com/kapsner/sjtable2df/tree/5a3290865b1a9f189ebe81f83d4d7a132ac2a617))
 -   updated vignette name; added cran-installation to readme
+    ([fc1faf4](https://github.com/joundso/sjtable2df/tree/fc1faf416482bed9ea39f595eedd894e5dddc0ed)) -
+    updated vignette name; added cran-installation to readme
     ([fc1faf4](https://github.com/kapsner/sjtable2df/tree/fc1faf416482bed9ea39f595eedd894e5dddc0ed))
 
 Full set of changes:
-[`v0.0.2...78aaf33`](https://github.com/kapsner/sjtable2df/compare/v0.0.2...78aaf33)
+[`v0.0.2...42f5f44`](https://github.com/joundso/sjtable2df/compare/v0.0.2...42f5f44)
+Full set of changes:
+[`v0.0.2...42f5f44`](https://github.com/kapsner/sjtable2df/compare/v0.0.2...42f5f44)
 
 ## v0.0.2 (2022-06-20)
 
 #### Bug fixes
 
 -   working on utf8 fix for windows
+    ([6e36249](https://github.com/joundso/sjtable2df/tree/6e36249f725f6e61771bd39bf90aca55923ff2f8)) -
+    working on utf8 fix for windows
     ([6e36249](https://github.com/kapsner/sjtable2df/tree/6e36249f725f6e61771bd39bf90aca55923ff2f8))
 -   updated logic to use read\_html
+    ([1582bc1](https://github.com/joundso/sjtable2df/tree/1582bc18b7820391c75b7b8896e7c6bf447f5300)) -
+    updated logic to use read\_html
     ([1582bc1](https://github.com/kapsner/sjtable2df/tree/1582bc18b7820391c75b7b8896e7c6bf447f5300))
 
 #### Tests
 
 -   added more unit tests with snapshots!
+    ([beab215](https://github.com/joundso/sjtable2df/tree/beab215e64b5b9fd72dfbba02d1eaa57dd6f906b)) -
+    added more unit tests with snapshots!
     ([beab215](https://github.com/kapsner/sjtable2df/tree/beab215e64b5b9fd72dfbba02d1eaa57dd6f906b))
 
 #### CI
 
 -   updated gha
+    ([fcda225](https://github.com/joundso/sjtable2df/tree/fcda2258aef638af6b107c32cb27a6ff7a969f92)) -
+    updated gha
     ([fcda225](https://github.com/kapsner/sjtable2df/tree/fcda2258aef638af6b107c32cb27a6ff7a969f92))
 
 #### Docs
 
 -   added readme; some other refactorings
+    ([20be826](https://github.com/joundso/sjtable2df/tree/20be826f7508732a9876f01a3ec148a071bb66b1)) -
+    added readme; some other refactorings
     ([20be826](https://github.com/kapsner/sjtable2df/tree/20be826f7508732a9876f01a3ec148a071bb66b1))
 -   updated return values
+    ([521ce9b](https://github.com/joundso/sjtable2df/tree/521ce9b35c26f2bec98ada664f8d0707a2d8e5d6)) -
+    updated return values
     ([521ce9b](https://github.com/kapsner/sjtable2df/tree/521ce9b35c26f2bec98ada664f8d0707a2d8e5d6))
 
 #### Other changes
 
 -   updated news.md
+    ([cdd03a7](https://github.com/joundso/sjtable2df/tree/cdd03a79fb8bb8d90d333da76466689bbbcbd7b3)) -
+    updated news.md
     ([cdd03a7](https://github.com/kapsner/sjtable2df/tree/cdd03a79fb8bb8d90d333da76466689bbbcbd7b3))
 -   fixed formatting of lintr-file
+    ([b88df55](https://github.com/joundso/sjtable2df/tree/b88df551cbac6fe46c38f348d2802218c21fa9a3)) -
+    fixed formatting of lintr-file
     ([b88df55](https://github.com/kapsner/sjtable2df/tree/b88df551cbac6fe46c38f348d2802218c21fa9a3))
 -   merging into main
+    ([ae8ffc5](https://github.com/joundso/sjtable2df/tree/ae8ffc53f75e6a38372e5654ac2525152040ee5a)) -
+    merging into main
     ([ae8ffc5](https://github.com/kapsner/sjtable2df/tree/ae8ffc53f75e6a38372e5654ac2525152040ee5a))
 -   updated lintr
+    ([c7823a2](https://github.com/joundso/sjtable2df/tree/c7823a2c5598158603765ff2357ea4c51e9b564c)) -
+    updated lintr
     ([c7823a2](https://github.com/kapsner/sjtable2df/tree/c7823a2c5598158603765ff2357ea4c51e9b564c))
 -   fixed badge url
+    ([4eae523](https://github.com/joundso/sjtable2df/tree/4eae523c3d8246649cd034011ceecf6bb89311c4)) -
+    fixed badge url
     ([4eae523](https://github.com/kapsner/sjtable2df/tree/4eae523c3d8246649cd034011ceecf6bb89311c4))
 -   updated description and news.md
+    ([550db85](https://github.com/joundso/sjtable2df/tree/550db85ce75ae08c1b5902315ef5301b9e392a76)) -
+    updated description and news.md
     ([550db85](https://github.com/kapsner/sjtable2df/tree/550db85ce75ae08c1b5902315ef5301b9e392a76))
 -   fixed missing whitespace
+    ([7a40408](https://github.com/joundso/sjtable2df/tree/7a404088942eb9463ead3d6f63a547d51f833efb)) -
+    fixed missing whitespace
     ([7a40408](https://github.com/kapsner/sjtable2df/tree/7a404088942eb9463ead3d6f63a547d51f833efb))
 -   added news.md
+    ([c9205d7](https://github.com/joundso/sjtable2df/tree/c9205d775a889d4ca55e58a4530b3646f41d40a7)) -
+    added news.md
     ([c9205d7](https://github.com/kapsner/sjtable2df/tree/c9205d775a889d4ca55e58a4530b3646f41d40a7))
 
+Full set of changes:
+[`v0.0.1...v0.0.2`](https://github.com/joundso/sjtable2df/compare/v0.0.1...v0.0.2)
 Full set of changes:
 [`v0.0.1...v0.0.2`](https://github.com/kapsner/sjtable2df/compare/v0.0.1...v0.0.2)
 
 ## v0.0.1 (2021-12-20)
 
+Full set of changes:
+[`e4e9992...v0.0.1`](https://github.com/joundso/sjtable2df/compare/e4e9992...v0.0.1)
 Full set of changes:
 [`e4e9992...v0.0.1`](https://github.com/kapsner/sjtable2df/compare/e4e9992...v0.0.1)

--- a/R/mtab2df.R
+++ b/R/mtab2df.R
@@ -135,10 +135,13 @@ mtab2df <- function(mtab, n_models, output = "data.table", ...) {
   suppress_rows <- which(
     stats_table[, 1] == suppress_term):nrow(stats_table)
 
-  # suprress info
+  # suppress info
   for (colnum in suppress_cols) {
     stats_table[suppress_rows, (colnum) := ""]
   }
+  
+  # keep significance level information only in the first column:
+  stats_table[nrow(stats_table), 2:ncol(stats_table) := ""]
 
   # data.table output
   if (output %in% c("data.table", "data.frame")) {

--- a/R/mtab2df.R
+++ b/R/mtab2df.R
@@ -28,9 +28,6 @@
 #' @return The table is returned as an R object of the type specified with
 #'   the `output` argument.
 #'
-#' @import data.table
-#' @importFrom magrittr "%>%"
-
 #' @examples
 #' \donttest{
 #' set.seed(1)

--- a/R/mtab2df.R
+++ b/R/mtab2df.R
@@ -163,7 +163,7 @@ mtab2df <- function(mtab, n_models, output = "data.table", ...) {
   if (sum(first_col_dupl) > 0) {
     # if other values are an empty string
     if (sum(first_col_dupl) == ncol(stats_table) ||
-        identical(first_col_dupl, setNames(
+        identical(first_col_dupl, stats::setNames(
           object = as.logical(abs(empty_other_cols - 1)),
           nm = names(empty_other_cols)
         ))) {

--- a/R/mtab2df.R
+++ b/R/mtab2df.R
@@ -139,9 +139,39 @@ mtab2df <- function(mtab, n_models, output = "data.table", ...) {
   for (colnum in suppress_cols) {
     stats_table[suppress_rows, (colnum) := ""]
   }
-  
-  # keep significance level information only in the first column:
-  stats_table[nrow(stats_table), 2:ncol(stats_table) := ""]
+
+  # check for duplicates in last row
+  first_col_dupl <- vapply(
+    X = stats_table[nrow(stats_table), 2:ncol(stats_table)],
+    FUN = function(x) {
+      # has column >1 same value as col 1?
+      stats_table[nrow(stats_table), 1] == x
+    },
+    FUN.VALUE = logical(1)
+  )
+
+  # check for empty values in other cols
+  empty_other_cols <- vapply(
+    X = stats_table[nrow(stats_table), 2:ncol(stats_table)],
+    FUN = function(x) {
+      # has column >1 empty string?
+      "" == x
+    },
+    FUN.VALUE = logical(1)
+  )
+
+  if (sum(first_col_dupl) > 0) {
+    # if other values are an empty string
+    if (sum(first_col_dupl) == ncol(stats_table) ||
+        identical(first_col_dupl, setNames(
+          object = as.logical(abs(empty_other_cols - 1)),
+          nm = names(empty_other_cols)
+        ))) {
+      # replace with empty string
+      # keep significance level information only in the first column:
+      stats_table[nrow(stats_table), 2:ncol(stats_table) := ""]
+    }
+  }
 
   # data.table output
   if (output %in% c("data.table", "data.frame")) {

--- a/R/xtab2df.R
+++ b/R/xtab2df.R
@@ -30,9 +30,6 @@
 #' @return The table is returned as an R object of the type specified with
 #'   the `output` argument.
 #'
-#' @import data.table
-#' @importFrom magrittr "%>%"
-#'
 #' @inheritParams kableExtra::add_footnote
 #'
 #' @examples

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,3 @@
+#' @import data.table
+#' @importFrom magrittr "%>%"
+NULL

--- a/data-raw/devstuffs.R
+++ b/data-raw/devstuffs.R
@@ -56,6 +56,7 @@ usethis::use_package("magrittr", type = "Imports")
 usethis::use_package("rvest", type = "Imports")
 usethis::use_package("xml2", type = "Imports")
 usethis::use_package("rlang", type = "Imports")
+usethis::use_package("stats", type = "Imports")
 
 # Suggests
 usethis::use_package("testthat", type = "Suggests", min_version = "3.0.1")
@@ -64,7 +65,6 @@ usethis::use_package("knitr", type = "Suggests")
 usethis::use_package("rmarkdown", type = "Suggests")
 usethis::use_package("mlbench", type = "Suggests")
 usethis::use_package("sjPlot", type = "Suggests")
-usethis::use_package("stats", type = "Suggests")
 usethis::use_package("lme4", type = "Suggests")
 
 

--- a/data-raw/devstuffs.R
+++ b/data-raw/devstuffs.R
@@ -19,7 +19,7 @@ my_desc$set_authors(c(
 # Remove some author fields
 my_desc$del("Maintainer")
 # Set the version
-my_desc$set_version("0.0.2.9002")
+my_desc$set_version("0.0.2.9003")
 # The title of your package
 my_desc$set(Title = "Convert 'sjPlot' HTML-Tables to R 'data.frame'")
 # The description of your package

--- a/tests/testthat/test-mtab2df.R
+++ b/tests/testthat/test-mtab2df.R
@@ -179,3 +179,65 @@ test_that(
 
   }
 )
+
+test_that(
+  desc = "correct functioning of mtab2df with significance: glm",
+  code = {
+
+    local_edition(3)
+
+    set.seed(1)
+    dataset <- data.table::data.table(
+      "var1" = factor(sample(
+        x = c("yes", "no"),
+        size = 100,
+        replace = TRUE,
+        prob = c(.3, .7)
+      )),
+      "var2" = factor(sample(
+        x = c("yes", "no"),
+        size = 100,
+        replace = TRUE
+      )),
+      "var3" = rnorm(100)
+    )
+
+    # models
+    m0 <- stats::glm(
+      var1 ~ 1,
+      data = dataset,
+      family = binomial(link = "logit")
+    )
+    m1 <- stats::glm(
+      var1 ~ var2,
+      data = dataset,
+      family = binomial(link = "logit")
+    )
+    m2 <- stats::glm(
+      var1 ~ var2 + var3,
+      data = dataset,
+      family = binomial(link = "logit")
+    )
+
+    m_table <- sjPlot::tab_model(m0, m1, m2,
+                                 show.aic = TRUE,
+                                 p.style = "numeric_star")
+
+    final_tab <- sjtable2df::mtab2df(mtab = m_table, n_models = 3)
+
+    expect_type(final_tab, "list")
+    expect_true(inherits(final_tab, "data.table"))
+    expect_true(nrow(final_tab) == 7)
+
+    empty_other_cols <- vapply(
+      X = final_tab[nrow(final_tab), 2:ncol(final_tab)],
+      FUN = function(x) {
+        # has column >1 empty string?
+        "" == x
+      },
+      FUN.VALUE = logical(1)
+    )
+
+    expect_true(sum(empty_other_cols) == ncol(final_tab) - 1)
+  }
+)


### PR DESCRIPTION
Currently something like this 
```r
  res <- sjPlot::tab_model(fit.coxph,
                           digits = 4,
                           emph.p = TRUE,
                           p.style = "numeric_star") %>%
    sjtable2df::mtab2df(mtab = ., n_models = 1)
```

produces a table like this (see the last row):
![grafik](https://user-images.githubusercontent.com/56686638/205252182-e315fe94-618c-42e4-8ea1-cdb2ef85577d.png)

Goal of this PR: Only keep the first column of the last row to remove duplicate information about the significante levels (`* p<0.05   ** p<0.01   *** p<0.001`) from all other columns.